### PR TITLE
Honour CFLAGS from outside

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,10 @@ project(pd-pmpd C)
 # Platform-specific and compiler-specific settings
 if(MSVC)
   # MSVC-specific flags
-  set(CMAKE_C_FLAGS "/W3 /O2 /Ot /fp:fast")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W3 /O2 /Ot /fp:fast")
 else()
   # GCC/Clang-specific flags
-  set(CMAKE_C_FLAGS "-Wall -O3 -ffast-math -ffinite-math-only -finline-functions -funroll-loops")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -O3 -ffast-math -ffinite-math-only -finline-functions -funroll-loops")
 endif()
 
 if(APPLE)


### PR DESCRIPTION
yet another PR i had to do for preparing the Debian packages.

currently, the compiler flags are set unconditionally in https://github.com/ch-nry/pd-pmpd/blob/c89f3273900efa975430a536fa1159f0f16a155f/CMakeLists.txt#L10

while this probably works find in many cases, it it undesired in the Debian case were we want to be able to inject specific CFLAGS (mostly for hardening the binaries).

This PR *appends* the pmpd build flags to the `CFLAGS`, rather than overwriting whatever is there.