### PR TITLE
fix out of bounds inlet/outlet assignment

### DIFF
--- a/pmpd2d~.c
+++ b/pmpd2d~.c
@@ -469,7 +469,7 @@ void pmpd2d_tilde_inPosX(t_pmpd2d_tilde *x, t_float nb_inlet, t_float mass_1, t_
         pd_error(x, "too many inPosX assigned (increase limit with creation argument)");
         return;
     }
-    x->inPosX[x->nb_inPosX].nbr_inlet = max(0, min( x->nb_inlet,(int)nb_inlet));
+    x->inPosX[x->nb_inPosX].nbr_inlet = max(0, min( x->nb_inlet-1,(int)nb_inlet));
     x->inPosX[x->nb_inPosX].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->inPosX[x->nb_inPosX].influence = influence;
     x->nb_inPosX++;
@@ -483,7 +483,7 @@ void pmpd2d_tilde_inPosY(t_pmpd2d_tilde *x, t_float nb_inlet, t_float mass_1, t_
         pd_error(x, "too many inPosY assigned (increase limit with creation argument)");
         return;
     }
-    x->inPosY[x->nb_inPosY].nbr_inlet = max(0, min( x->nb_inlet,(int)nb_inlet));
+    x->inPosY[x->nb_inPosY].nbr_inlet = max(0, min( x->nb_inlet-1,(int)nb_inlet));
     x->inPosY[x->nb_inPosY].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->inPosY[x->nb_inPosY].influence = influence;
     x->nb_inPosY++;
@@ -495,7 +495,7 @@ void pmpd2d_tilde_inForceX(t_pmpd2d_tilde *x, t_float nb_inlet, t_float mass_1, 
         pd_error(x, "too many inForceX assigned (increase limit with creation argument)");
         return;
     }
-    x->inForceX[x->nb_inForceX].nbr_inlet = max(0, min( x->nb_inlet,(int)nb_inlet));
+    x->inForceX[x->nb_inForceX].nbr_inlet = max(0, min( x->nb_inlet-1,(int)nb_inlet));
     x->inForceX[x->nb_inForceX].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->inForceX[x->nb_inForceX].influence = influence;
     x->nb_inForceX++;
@@ -507,7 +507,7 @@ void pmpd2d_tilde_inForceY(t_pmpd2d_tilde *x, t_float nb_inlet, t_float mass_1, 
         pd_error(x, "too many inForceY assigned (increase limit with creation argument)");
         return;
     }
-    x->inForceY[x->nb_inForceY].nbr_inlet = max(0, min( x->nb_inlet,(int)nb_inlet));
+    x->inForceY[x->nb_inForceY].nbr_inlet = max(0, min( x->nb_inlet-1,(int)nb_inlet));
     x->inForceY[x->nb_inForceY].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->inForceY[x->nb_inForceY].influence = influence;
     x->nb_inForceY++;
@@ -519,7 +519,7 @@ void pmpd2d_tilde_outPosX(t_pmpd2d_tilde *x, t_float nb_outlet, t_float mass_1, 
         pd_error(x, "too many outPosX assigned (increase limit with creation argument)");
         return;
     }
-    x->outPosX[x->nb_outPosX].nbr_outlet = max(0, min( x->nb_outlet,(int)nb_outlet));
+    x->outPosX[x->nb_outPosX].nbr_outlet = max(0, min( x->nb_outlet-1,(int)nb_outlet));
     x->outPosX[x->nb_outPosX].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->outPosX[x->nb_outPosX].influence = influence;
     x->nb_outPosX++;
@@ -531,7 +531,7 @@ void pmpd2d_tilde_outPosY(t_pmpd2d_tilde *x, t_float nb_outlet, t_float mass_1, 
         pd_error(x, "too many outPosY assigned (increase limit with creation argument)");
         return;
     }
-    x->outPosY[x->nb_outPosY].nbr_outlet = max(0, min( x->nb_outlet,(int)nb_outlet));
+    x->outPosY[x->nb_outPosY].nbr_outlet = max(0, min( x->nb_outlet-1,(int)nb_outlet));
     x->outPosY[x->nb_outPosY].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->outPosY[x->nb_outPosY].influence = influence;
     x->nb_outPosY++;
@@ -543,7 +543,7 @@ void pmpd2d_tilde_outSpeedX(t_pmpd2d_tilde *x, t_float nb_outlet, t_float mass_1
         pd_error(x, "too many outSpeedX assigned (increase limit with creation argument)");
         return;
     }
-    x->outSpeedX[x->nb_outSpeedX].nbr_outlet = max(0, min( x->nb_outlet,(int)nb_outlet));
+    x->outSpeedX[x->nb_outSpeedX].nbr_outlet = max(0, min( x->nb_outlet-1,(int)nb_outlet));
     x->outSpeedX[x->nb_outSpeedX].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->outSpeedX[x->nb_outSpeedX].influence = influence;
     x->nb_outSpeedX++;
@@ -555,7 +555,7 @@ void pmpd2d_tilde_outSpeedY(t_pmpd2d_tilde *x, t_float nb_outlet, t_float mass_1
         pd_error(x, "too many outSpeedY assigned (increase limit with creation argument)");
         return;
     }
-    x->outSpeedY[x->nb_outSpeedY].nbr_outlet = max(0, min( x->nb_outlet,(int)nb_outlet));
+    x->outSpeedY[x->nb_outSpeedY].nbr_outlet = max(0, min( x->nb_outlet-1,(int)nb_outlet));
     x->outSpeedY[x->nb_outSpeedY].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->outSpeedY[x->nb_outSpeedY].influence = influence;
     x->nb_outSpeedY++;
@@ -567,7 +567,7 @@ void pmpd2d_tilde_outSpeed(t_pmpd2d_tilde *x, t_float nb_outlet, t_float mass_1,
         pd_error(x, "too many outSpeed assigned (increase limit with creation argument)");
         return;
     }
-    x->outSpeed[x->nb_outSpeed].nbr_outlet = max(0, min( x->nb_outlet,(int)nb_outlet));
+    x->outSpeed[x->nb_outSpeed].nbr_outlet = max(0, min( x->nb_outlet-1,(int)nb_outlet));
     x->outSpeed[x->nb_outSpeed].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->outSpeed[x->nb_outSpeed].influence = influence;
     x->nb_outSpeed++;

--- a/pmpd3d~.c
+++ b/pmpd3d~.c
@@ -512,7 +512,7 @@ void pmpd3d_tilde_inPosX(t_pmpd3d_tilde *x, t_float nb_inlet, t_float mass_1, t_
         pd_error(x, "too many inPosX assigned (increase limit with creation argument)");
         return;
     }
-    x->inPosX[x->nb_inPosX].nbr_inlet = max(0, min( x->nb_inlet,(int)nb_inlet));
+    x->inPosX[x->nb_inPosX].nbr_inlet = max(0, min( x->nb_inlet-1,(int)nb_inlet));
     x->inPosX[x->nb_inPosX].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->inPosX[x->nb_inPosX].influence = influence;
     x->nb_inPosX++;
@@ -526,7 +526,7 @@ void pmpd3d_tilde_inPosY(t_pmpd3d_tilde *x, t_float nb_inlet, t_float mass_1, t_
         pd_error(x, "too many inPosY assigned (increase limit with creation argument)");
         return;
     }
-    x->inPosY[x->nb_inPosY].nbr_inlet = max(0, min( x->nb_inlet,(int)nb_inlet));
+    x->inPosY[x->nb_inPosY].nbr_inlet = max(0, min( x->nb_inlet-1,(int)nb_inlet));
     x->inPosY[x->nb_inPosY].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->inPosY[x->nb_inPosY].influence = influence;
     x->nb_inPosY++;
@@ -540,7 +540,7 @@ void pmpd3d_tilde_inPosZ(t_pmpd3d_tilde *x, t_float nb_inlet, t_float mass_1, t_
         pd_error(x, "too many inPosZ assigned (increase limit with creation argument)");
         return;
     }
-    x->inPosZ[x->nb_inPosZ].nbr_inlet = max(0, min( x->nb_inlet,(int)nb_inlet));
+    x->inPosZ[x->nb_inPosZ].nbr_inlet = max(0, min( x->nb_inlet-1,(int)nb_inlet));
     x->inPosZ[x->nb_inPosZ].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->inPosZ[x->nb_inPosZ].influence = influence;
     x->nb_inPosZ++;
@@ -552,7 +552,7 @@ void pmpd3d_tilde_inForceX(t_pmpd3d_tilde *x, t_float nb_inlet, t_float mass_1, 
         pd_error(x, "too many inForceX assigned (increase limit with creation argument)");
         return;
     }
-    x->inForceX[x->nb_inForceX].nbr_inlet = max(0, min( x->nb_inlet,(int)nb_inlet));
+    x->inForceX[x->nb_inForceX].nbr_inlet = max(0, min( x->nb_inlet-1,(int)nb_inlet));
     x->inForceX[x->nb_inForceX].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->inForceX[x->nb_inForceX].influence = influence;
     x->nb_inForceX++;
@@ -564,7 +564,7 @@ void pmpd3d_tilde_inForceY(t_pmpd3d_tilde *x, t_float nb_inlet, t_float mass_1, 
         pd_error(x, "too many inForceY assigned (increase limit with creation argument)");
         return;
     }
-    x->inForceY[x->nb_inForceY].nbr_inlet = max(0, min( x->nb_inlet,(int)nb_inlet));
+    x->inForceY[x->nb_inForceY].nbr_inlet = max(0, min( x->nb_inlet-1,(int)nb_inlet));
     x->inForceY[x->nb_inForceY].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->inForceY[x->nb_inForceY].influence = influence;
     x->nb_inForceY++;
@@ -576,7 +576,7 @@ void pmpd3d_tilde_inForceZ(t_pmpd3d_tilde *x, t_float nb_inlet, t_float mass_1, 
         pd_error(x, "too many inForceZ assigned (increase limit with creation argument)");
         return;
     }
-    x->inForceZ[x->nb_inForceZ].nbr_inlet = max(0, min( x->nb_inlet,(int)nb_inlet));
+    x->inForceZ[x->nb_inForceZ].nbr_inlet = max(0, min( x->nb_inlet-1,(int)nb_inlet));
     x->inForceZ[x->nb_inForceZ].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->inForceZ[x->nb_inForceZ].influence = influence;
     x->nb_inForceZ++;
@@ -588,7 +588,7 @@ void pmpd3d_tilde_outPosX(t_pmpd3d_tilde *x, t_float nb_outlet, t_float mass_1, 
         pd_error(x, "too many outPosX assigned (increase limit with creation argument)");
         return;
     }
-    x->outPosX[x->nb_outPosX].nbr_outlet = max(0, min( x->nb_outlet,(int)nb_outlet));
+    x->outPosX[x->nb_outPosX].nbr_outlet = max(0, min( x->nb_outlet-1,(int)nb_outlet));
     x->outPosX[x->nb_outPosX].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->outPosX[x->nb_outPosX].influence = influence;
     x->nb_outPosX++;
@@ -600,7 +600,7 @@ void pmpd3d_tilde_outPosY(t_pmpd3d_tilde *x, t_float nb_outlet, t_float mass_1, 
         pd_error(x, "too many outPosY assigned (increase limit with creation argument)");
         return;
     }
-    x->outPosY[x->nb_outPosY].nbr_outlet = max(0, min( x->nb_outlet,(int)nb_outlet));
+    x->outPosY[x->nb_outPosY].nbr_outlet = max(0, min( x->nb_outlet-1,(int)nb_outlet));
     x->outPosY[x->nb_outPosY].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->outPosY[x->nb_outPosY].influence = influence;
     x->nb_outPosY++;
@@ -612,7 +612,7 @@ void pmpd3d_tilde_outPosZ(t_pmpd3d_tilde *x, t_float nb_outlet, t_float mass_1, 
         pd_error(x, "too many outPosZ assigned (increase limit with creation argument)");
         return;
     }
-    x->outPosZ[x->nb_outPosZ].nbr_outlet = max(0, min( x->nb_outlet,(int)nb_outlet));
+    x->outPosZ[x->nb_outPosZ].nbr_outlet = max(0, min( x->nb_outlet-1,(int)nb_outlet));
     x->outPosZ[x->nb_outPosZ].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->outPosZ[x->nb_outPosZ].influence = influence;
     x->nb_outPosZ++;
@@ -624,7 +624,7 @@ void pmpd3d_tilde_outSpeedX(t_pmpd3d_tilde *x, t_float nb_outlet, t_float mass_1
         pd_error(x, "too many outSpeedX assigned (increase limit with creation argument)");
         return;
     }
-    x->outSpeedX[x->nb_outSpeedX].nbr_outlet = max(0, min( x->nb_outlet,(int)nb_outlet));
+    x->outSpeedX[x->nb_outSpeedX].nbr_outlet = max(0, min( x->nb_outlet-1,(int)nb_outlet));
     x->outSpeedX[x->nb_outSpeedX].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->outSpeedX[x->nb_outSpeedX].influence = influence;
     x->nb_outSpeedX++;
@@ -636,7 +636,7 @@ void pmpd3d_tilde_outSpeedY(t_pmpd3d_tilde *x, t_float nb_outlet, t_float mass_1
         pd_error(x, "too many outSpeedY assigned (increase limit with creation argument)");
         return;
     }
-    x->outSpeedY[x->nb_outSpeedY].nbr_outlet = max(0, min( x->nb_outlet,(int)nb_outlet));
+    x->outSpeedY[x->nb_outSpeedY].nbr_outlet = max(0, min( x->nb_outlet-1,(int)nb_outlet));
     x->outSpeedY[x->nb_outSpeedY].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->outSpeedY[x->nb_outSpeedY].influence = influence;
     x->nb_outSpeedY++;
@@ -648,7 +648,7 @@ void pmpd3d_tilde_outSpeedZ(t_pmpd3d_tilde *x, t_float nb_outlet, t_float mass_1
         pd_error(x, "too many outSpeedZ assigned (increase limit with creation argument)");
         return;
     }
-    x->outSpeedZ[x->nb_outSpeedZ].nbr_outlet = max(0, min( x->nb_outlet,(int)nb_outlet));
+    x->outSpeedZ[x->nb_outSpeedZ].nbr_outlet = max(0, min( x->nb_outlet-1,(int)nb_outlet));
     x->outSpeedZ[x->nb_outSpeedZ].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->outSpeedZ[x->nb_outSpeedZ].influence = influence;
     x->nb_outSpeedZ++;
@@ -660,7 +660,7 @@ void pmpd3d_tilde_outSpeed(t_pmpd3d_tilde *x, t_float nb_outlet, t_float mass_1,
         pd_error(x, "too many outSpeed assigned (increase limit with creation argument)");
         return;
     }
-    x->outSpeed[x->nb_outSpeed].nbr_outlet = max(0, min( x->nb_outlet,(int)nb_outlet));
+    x->outSpeed[x->nb_outSpeed].nbr_outlet = max(0, min( x->nb_outlet-1,(int)nb_outlet));
     x->outSpeed[x->nb_outSpeed].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->outSpeed[x->nb_outSpeed].influence = influence;
     x->nb_outSpeed++;

--- a/pmpd~.c
+++ b/pmpd~.c
@@ -381,7 +381,7 @@ void pmpd_tilde_inPos(t_pmpd_tilde *x, t_float nb_inlet, t_float mass_1, t_float
         pd_error(x, "too many inPos assigned (increase limit with creation argument)");
         return;
     }
-    x->inPos[x->nb_inPos].nbr_inlet = max(0, min( x->nb_inlet,(int)nb_inlet));
+    x->inPos[x->nb_inPos].nbr_inlet = max(0, min( x->nb_inlet-1,(int)nb_inlet));
     x->inPos[x->nb_inPos].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->inPos[x->nb_inPos].influence = influence;
     x->nb_inPos++;
@@ -396,7 +396,7 @@ void pmpd_tilde_inForce(t_pmpd_tilde *x, t_float nb_inlet, t_float mass_1, t_flo
         pd_error(x, "too many inForce assigned (increase limit with creation argument)");
         return;
     }
-    x->inForce[x->nb_inForce].nbr_inlet = max(0, min( x->nb_inlet,(int)nb_inlet));
+    x->inForce[x->nb_inForce].nbr_inlet = max(0, min( x->nb_inlet-1,(int)nb_inlet));
     x->inForce[x->nb_inForce].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->inForce[x->nb_inForce].influence = influence;
     x->nb_inForce++;
@@ -411,7 +411,7 @@ void pmpd_tilde_outPos(t_pmpd_tilde *x, t_float nb_outlet, t_float mass_1, t_flo
         pd_error(x, "too many outPos assigned (increase limit with creation argument)");
         return;
     }
-    x->outPos[x->nb_outPos].nbr_outlet = max(0, min( x->nb_outlet,(int)nb_outlet));
+    x->outPos[x->nb_outPos].nbr_outlet = max(0, min( x->nb_outlet-1,(int)nb_outlet));
     x->outPos[x->nb_outPos].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->outPos[x->nb_outPos].influence = influence;
     x->nb_outPos++ ;
@@ -426,7 +426,7 @@ void pmpd_tilde_outSpeed(t_pmpd_tilde *x, t_float nb_outlet, t_float mass_1, t_f
         pd_error(x, "too many outSpeed assigned (increase limit with creation argument)");
         return;
     }
-    x->outSpeed[x->nb_outSpeed].nbr_outlet = max(0, min( x->nb_outlet,(int)nb_outlet));
+    x->outSpeed[x->nb_outSpeed].nbr_outlet = max(0, min( x->nb_outlet-1,(int)nb_outlet));
     x->outSpeed[x->nb_outSpeed].mass1 = &x->mass[max(0, min ( x->nb_mass, (int)mass_1))];
     x->outSpeed[x->nb_outSpeed].influence = influence;
     x->nb_outSpeed++ ;


### PR DESCRIPTION
pd crashed, when trying to assign a force, position or speed to a non-existing inlet or outlet index.

this happened because the bounds were set between 0 and `x->nb_inlet` (resp. `x->nb_outlet`), which is a max count and not max index. so the fix here is to add `-1` in these cases.