### PR TITLE
set linux build runners to ubuntu-20.04

### DIFF
--- a/.github/workflows/build-pd-externals.yml
+++ b/.github/workflows/build-pd-externals.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   build_linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         arch: [amd64, arm64]
@@ -41,7 +41,7 @@ jobs:
         path: build/package/pmpd
 
   build_linux_arm7:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
support older linux versions by avoiding error "version `GLIBC_2.34` not found"